### PR TITLE
Add analyzeSong and integrate into SongDetailPage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,2 @@
-@@ .. @@
- VITE_YOUTUBE_API_KEY=YOUR_YOUTUBE_API_KEY_HERE
--VITE_API_BASE_URL=http://localhost:3001/api    # (백엔드가 따로 있다면 URL 맞춰서)
-+VITE_BACKEND_URL=http://localhost:5001
+VITE_YOUTUBE_API_KEY=YOUR_YOUTUBE_API_KEY_HERE
+VITE_BACKEND_URL=http://localhost:5001

--- a/project/src/pages/SongDetailPage.tsx
+++ b/project/src/pages/SongDetailPage.tsx
@@ -6,7 +6,7 @@ import SearchBar from '../components/SearchBar';
 import YouTubePlayer from '../components/YouTubePlayer';
 import ChordChart from '../components/ChordChart';
 import ChordProgression from '../components/ChordProgression';
-import { getSongDetail } from '../utils/api';
+import { getSongDetail, analyzeSong } from '../utils/api';
 import { SongDetail } from '../types/song';
 
 const SongDetailPage: React.FC = () => {
@@ -28,7 +28,8 @@ const SongDetailPage: React.FC = () => {
       setLoading(true);
       try {
         const detail = await getSongDetail(id);
-        setSongDetail(detail);
+        const analysis = await analyzeSong(id);
+        setSongDetail({ ...detail, ...analysis } as SongDetail);
       } catch (err) {
         console.error('Error loading song detail:', err);
         setError('곡 정보를 불러오는 중 오류가 발생했습니다.');

--- a/project/src/utils/api.ts
+++ b/project/src/utils/api.ts
@@ -17,7 +17,17 @@ export interface SongDetail {
   // 필요에 따라 contentDetails 등 추가 정의 가능
 }
 
+/** 분석 결과 DTO */
+export interface AnalyzeResult {
+  bpm: number;
+  signature: string;
+  key: string;
+  chords: { chord: string; timestamp: number; duration: number }[];
+  chordCharts: { chord: string; frets: number[]; fingers: number[] }[];
+}
+
 const API_KEY = import.meta.env.VITE_YOUTUBE_API_KEY;
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
 /**
  * 유튜브에서 영상 리스트 검색
@@ -84,4 +94,24 @@ export const getSongDetail = async (
     thumbnailUrl: vid.snippet.thumbnails.high.url,
     // contentDetails 등 추가 정보가 필요하면 여기에 할당
   };
+};
+
+/**
+ * 백엔드 서버에서 곡 분석 결과 조회
+ * @param videoId 유튜브 동영상 ID
+ */
+export const analyzeSong = async (
+  videoId: string
+): Promise<AnalyzeResult> => {
+  const url = `${BACKEND_URL}/analyze`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ videoId })
+  });
+  if (!res.ok) throw new Error(`Analyze Error: ${res.status}`);
+  const data = await res.json();
+  return data as AnalyzeResult;
 };


### PR DESCRIPTION
## Summary
- provide backend URL in `.env.example`
- add song analysis API helper
- call analysis when loading song detail and merge data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687fd367a8348324b7d051170fa2aa99