### PR TITLE
Fix env example for frontend

### DIFF
--- a/project/.env.example
+++ b/project/.env.example
@@ -1,2 +1,2 @@
 VITE_YOUTUBE_API_KEY=YOUR_YOUTUBE_API_KEY_HERE
-VITE_API_BASE_URL=http://localhost:3001/api    # (백엔드가 따로 있다면 URL 맞춰서)
+VITE_BACKEND_URL=http://localhost:5001


### PR DESCRIPTION
## Summary
- clean up project env example file to use backend URL

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd5402e94832492e2a5b2d4dabcca